### PR TITLE
File I/O streaming + integration tests

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	id3v2 "github.com/bogem/id3v2/v2"
+)
+
+// minimalMP3Header is a valid empty ID3v2.4 tag header (10 bytes).
+// id3v2.Open accepts this and Save() will rewrite the file with new frames.
+var minimalMP3Header = []byte{'I', 'D', '3', 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+func writeMinimalMP3(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, minimalMP3Header, 0644); err != nil {
+		t.Fatalf("failed to create test mp3: %v", err)
+	}
+}
+
+func TestProcessFiles_OriginalUnmodified(t *testing.T) {
+	tempDir := t.TempDir()
+	mp3Path := filepath.Join(tempDir, "song.mp3")
+	writeMinimalMP3(t, mp3Path)
+
+	originalBytes, err := os.ReadFile(mp3Path)
+	if err != nil {
+		t.Fatalf("failed to read original: %v", err)
+	}
+
+	lyricsPath := filepath.Join(tempDir, "song.lrc")
+	if err := os.WriteFile(lyricsPath, []byte("[00:01.00]Hello\n[00:02.00]World"), 0644); err != nil {
+		t.Fatalf("failed to write lyrics: %v", err)
+	}
+
+	if err := processFiles(mp3Path, lyricsPath, "eng"); err != nil {
+		t.Fatalf("processFiles failed: %v", err)
+	}
+
+	afterBytes, err := os.ReadFile(mp3Path)
+	if err != nil {
+		t.Fatalf("failed to read original after processing: %v", err)
+	}
+	if !bytes.Equal(originalBytes, afterBytes) {
+		t.Errorf("original MP3 was modified by processFiles; want unchanged")
+	}
+
+	tag, err := id3v2.Open(mp3Path, id3v2.Options{Parse: true})
+	if err != nil {
+		t.Fatalf("failed to reopen original: %v", err)
+	}
+	defer tag.Close()
+	if frames := tag.GetFrames("SYLT"); len(frames) != 0 {
+		t.Errorf("original has %d SYLT frames; want 0", len(frames))
+	}
+}
+
+func TestProcessFiles_LargeFileStreaming(t *testing.T) {
+	tempDir := t.TempDir()
+	mp3Path := filepath.Join(tempDir, "big.mp3")
+
+	// Build a 5 MB "MP3": valid ID3v2 header + 5 MB of zero-padding (audio frames).
+	// We don't need real MP3 audio frames — id3v2 only reads the tag area.
+	const padSize = 5 * 1024 * 1024
+	f, err := os.Create(mp3Path)
+	if err != nil {
+		t.Fatalf("failed to create big mp3: %v", err)
+	}
+	if _, err := f.Write(minimalMP3Header); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := f.Write(make([]byte, padSize)); err != nil {
+		t.Fatalf("write padding: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	lyricsPath := filepath.Join(tempDir, "big.lrc")
+	if err := os.WriteFile(lyricsPath, []byte("[00:01.00]X"), 0644); err != nil {
+		t.Fatalf("write lyrics: %v", err)
+	}
+
+	if err := processFiles(mp3Path, lyricsPath, "eng"); err != nil {
+		t.Fatalf("processFiles failed: %v", err)
+	}
+
+	outPath := getOutputPath(mp3Path)
+	info, err := os.Stat(outPath)
+	if err != nil {
+		t.Fatalf("output file not created: %v", err)
+	}
+	// Output should be roughly the same size as input plus the small SYLT frame.
+	if info.Size() < padSize {
+		t.Errorf("output size %d too small; want >= %d", info.Size(), padSize)
+	}
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -57,7 +57,7 @@ func TestProcessFiles_OriginalUnmodified(t *testing.T) {
 	}
 }
 
-func TestProcessFiles_LargeFileStreaming(t *testing.T) {
+func TestProcessFiles_LargeFileRoundtrip(t *testing.T) {
 	tempDir := t.TempDir()
 	mp3Path := filepath.Join(tempDir, "big.mp3")
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -97,3 +97,77 @@ func TestProcessFiles_LargeFileRoundtrip(t *testing.T) {
 		t.Errorf("output size %d too small; want >= %d", info.Size(), padSize)
 	}
 }
+
+func TestProcessFiles_RoundTripSYLT(t *testing.T) {
+	tempDir := t.TempDir()
+	mp3Path := filepath.Join(tempDir, "song.mp3")
+	writeMinimalMP3(t, mp3Path)
+
+	lyricsPath := filepath.Join(tempDir, "song.lrc")
+	lrcContent := "[00:01.000]Hello\n[00:02.500]World\n[00:10.250]End"
+	if err := os.WriteFile(lyricsPath, []byte(lrcContent), 0644); err != nil {
+		t.Fatalf("failed to write lyrics: %v", err)
+	}
+
+	if err := processFiles(mp3Path, lyricsPath, "eng"); err != nil {
+		t.Fatalf("processFiles failed: %v", err)
+	}
+
+	outputPath := getOutputPath(mp3Path)
+	tag, err := id3v2.Open(outputPath, id3v2.Options{Parse: true})
+	if err != nil {
+		t.Fatalf("failed to open output: %v", err)
+	}
+	defer tag.Close()
+
+	frames := tag.GetFrames("SYLT")
+	if len(frames) != 1 {
+		t.Fatalf("expected 1 SYLT frame, got %d", len(frames))
+	}
+
+	uf, ok := frames[0].(id3v2.UnknownFrame)
+	if !ok {
+		t.Fatalf("frame is not UnknownFrame: %T", frames[0])
+	}
+
+	entries, lang, err := parseSYLTFrame(uf.Body)
+	if err != nil {
+		t.Fatalf("parseSYLTFrame failed: %v", err)
+	}
+	if lang != "eng" {
+		t.Errorf("lang = %q, want %q", lang, "eng")
+	}
+
+	want := []LyricEntry{
+		{Text: "Hello", Ms: 1000},
+		{Text: "World", Ms: 2500},
+		{Text: "End", Ms: 10250},
+	}
+	if len(entries) != len(want) {
+		t.Fatalf("got %d entries, want %d", len(entries), len(want))
+	}
+	for i := range want {
+		if entries[i] != want[i] {
+			t.Errorf("entry[%d] = %+v, want %+v", i, entries[i], want[i])
+		}
+	}
+}
+
+func TestReadSYLT_AfterProcess(t *testing.T) {
+	tempDir := t.TempDir()
+	mp3Path := filepath.Join(tempDir, "song.mp3")
+	writeMinimalMP3(t, mp3Path)
+
+	lyricsPath := filepath.Join(tempDir, "song.lrc")
+	if err := os.WriteFile(lyricsPath, []byte("[00:01.00]Hello"), 0644); err != nil {
+		t.Fatalf("write lyrics: %v", err)
+	}
+	if err := processFiles(mp3Path, lyricsPath, "und"); err != nil {
+		t.Fatalf("processFiles: %v", err)
+	}
+
+	outputPath := getOutputPath(mp3Path)
+	if err := readSYLT(outputPath); err != nil {
+		t.Errorf("readSYLT returned error on file produced by processFiles: %v", err)
+	}
+}

--- a/sylt.go
+++ b/sylt.go
@@ -282,6 +282,7 @@ func copyFile(src, dst string) error {
 
 	if _, err := io.Copy(out, in); err != nil {
 		out.Close()
+		os.Remove(dst)
 		return err
 	}
 	return out.Close()

--- a/sylt.go
+++ b/sylt.go
@@ -250,6 +250,7 @@ func processFiles(mp3File, lyricsFile, lang string) error {
 	// Open the copy and add the SYLT frame
 	newTag, err := id3v2.Open(outputPath, id3v2.Options{Parse: true})
 	if err != nil {
+		os.Remove(outputPath)
 		return fmt.Errorf("failed to open output MP3 file: %v", err)
 	}
 	defer func() {
@@ -261,6 +262,7 @@ func processFiles(mp3File, lyricsFile, lang string) error {
 	newTag.AddFrame("SYLT", id3v2.UnknownFrame{Body: payload})
 
 	if err := newTag.Save(); err != nil {
+		os.Remove(outputPath)
 		return fmt.Errorf("failed to save MP3 file: %v", err)
 	}
 
@@ -285,7 +287,11 @@ func copyFile(src, dst string) error {
 		os.Remove(dst)
 		return err
 	}
-	return out.Close()
+	if err := out.Close(); err != nil {
+		os.Remove(dst)
+		return err
+	}
+	return nil
 }
 
 // parseSYLTFrame parses SYLT frame data and returns entries and language code

--- a/sylt.go
+++ b/sylt.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -235,36 +236,18 @@ func processFiles(mp3File, lyricsFile, lang string) error {
 		return fmt.Errorf("failed to parse lyrics: %v", err)
 	}
 
-	// Open MP3 file to read tags
-	tag, err := id3v2.Open(mp3File, id3v2.Options{Parse: true})
-	if err != nil {
-		return fmt.Errorf("failed to open MP3 file: %v", err)
-	}
-	defer func() {
-		if closeErr := tag.Close(); closeErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close MP3 file: %v\n", closeErr)
-		}
-	}()
-
-	// Build and add SYLT frame
+	// Build SYLT payload
 	payload := buildSYLT(entries, lang)
-	tag.AddFrame("SYLT", id3v2.UnknownFrame{Body: payload})
 
-	// Generate output path and save
+	// Generate output path
 	outputPath := getOutputPath(mp3File)
 
-	// Copy original file to new location first
-	input, err := os.ReadFile(mp3File)
-	if err != nil {
-		return fmt.Errorf("failed to read original MP3 file: %v", err)
-	}
-	if err := os.WriteFile(outputPath, input, 0644); err != nil {
-		return fmt.Errorf("failed to create output file: %v", err)
+	// Stream-copy the source MP3 to the output path
+	if err := copyFile(mp3File, outputPath); err != nil {
+		return fmt.Errorf("failed to copy MP3 to output: %v", err)
 	}
 
-	// The tag will be closed by the defer function
-
-	// Open the new file and add SYLT frame
+	// Open the copy and add the SYLT frame
 	newTag, err := id3v2.Open(outputPath, id3v2.Options{Parse: true})
 	if err != nil {
 		return fmt.Errorf("failed to open output MP3 file: %v", err)
@@ -275,7 +258,6 @@ func processFiles(mp3File, lyricsFile, lang string) error {
 		}
 	}()
 
-	// Add SYLT frame to new file
 	newTag.AddFrame("SYLT", id3v2.UnknownFrame{Body: payload})
 
 	if err := newTag.Save(); err != nil {
@@ -283,6 +265,26 @@ func processFiles(mp3File, lyricsFile, lang string) error {
 	}
 
 	return nil
+}
+
+// copyFile streams src to dst using io.Copy to avoid loading large files into memory.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 // parseSYLTFrame parses SYLT frame data and returns entries and language code


### PR DESCRIPTION
## Summary
- Streams MP3 copy with `io.Copy` to avoid loading large files into memory.
- Removes the redundant `AddFrame("SYLT", ...)` call on the original tag (it was never saved).
- `copyFile` cleans up the partial output file if `io.Copy` fails so retries start clean.
- Adds integration tests covering original-file invariance, large-file round-trip, SYLT round-trip via `parseSYLTFrame`, and the `readSYLT` read path.

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] Manual: run the binary on a real MP3 to confirm output file has SYLT and original is untouched.

Closes #7
Closes #8
Closes #13