### PR TITLE
Parser flexibility: VTT hours and multi-timestamp LRC

### DIFF
--- a/sylt.go
+++ b/sylt.go
@@ -194,7 +194,8 @@ func parseVTT(content string) ([]LyricEntry, error) {
 		milliseconds, _ := strconv.Atoi(matches[4])
 
 		text := ""
-		for j := i + 1; j < len(lines); j++ {
+		j := i + 1
+		for ; j < len(lines); j++ {
 			nextLine := strings.TrimSpace(lines[j])
 			if nextLine == "" {
 				break
@@ -204,6 +205,7 @@ func parseVTT(content string) ([]LyricEntry, error) {
 			}
 			text += nextLine
 		}
+		i = j // skip past consumed text lines so they aren't re-scanned
 
 		if text == "" {
 			continue

--- a/sylt.go
+++ b/sylt.go
@@ -47,28 +47,52 @@ func parseLyrics(content string, filename string) ([]LyricEntry, error) {
 	}
 }
 
-// parseLRC parses LRC format with both [mm:ss.xx] and [mm:ss.xxx] timestamps
+// parseLRC parses LRC format. Lines may contain one or more leading
+// [mm:ss.xx] or [mm:ss.xxx] timestamps; each timestamp produces an entry
+// pointing at the same text.
 func parseLRC(content string) ([]LyricEntry, error) {
 	var entries []LyricEntry
-	lrcRegex := regexp.MustCompile(`\[(\d{2}):(\d{2})\.(\d{2,3})\](.*)`)
+	tsRegex := regexp.MustCompile(`\[(\d{2}):(\d{2})\.(\d{2,3})\]`)
 
 	for _, line := range strings.Split(content, "\n") {
-		matches := lrcRegex.FindStringSubmatch(strings.TrimSpace(line))
-		if len(matches) == 5 {
-			minutes, _ := strconv.Atoi(matches[1])
-			seconds, _ := strconv.Atoi(matches[2])
-			fracStr := matches[3]
-			text := strings.TrimSpace(matches[4])
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
 
-			if text == "" {
-				continue
+		matches := tsRegex.FindAllStringSubmatchIndex(line, -1)
+		if len(matches) == 0 {
+			continue
+		}
+
+		// Verify all matches form a contiguous prefix at the start of the line.
+		prefixEnd := 0
+		valid := true
+		for _, m := range matches {
+			if m[0] != prefixEnd {
+				valid = false
+				break
 			}
+			prefixEnd = m[1]
+		}
+		if !valid {
+			continue
+		}
 
-			// Handle both 2 and 3 digit fractions
+		text := strings.TrimSpace(line[prefixEnd:])
+		if text == "" {
+			continue
+		}
+
+		for _, m := range matches {
+			minutes, _ := strconv.Atoi(line[m[2]:m[3]])
+			seconds, _ := strconv.Atoi(line[m[4]:m[5]])
+			fracStr := line[m[6]:m[7]]
+
 			var milliseconds int
 			if len(fracStr) == 2 {
 				milliseconds, _ = strconv.Atoi(fracStr)
-				milliseconds *= 10 // Convert centiseconds to milliseconds
+				milliseconds *= 10
 			} else {
 				milliseconds, _ = strconv.Atoi(fracStr)
 			}

--- a/sylt.go
+++ b/sylt.go
@@ -157,50 +157,60 @@ func parseSRT(content string) ([]LyricEntry, error) {
 	return entries, nil
 }
 
-// parseVTT parses WebVTT format
+// parseVTT parses WebVTT format. Timestamps may be either mm:ss.mmm or
+// hh:mm:ss.mmm and any amount of whitespace is permitted around the
+// '-->' separator. The optional WEBVTT header line is skipped if present.
 func parseVTT(content string) ([]LyricEntry, error) {
 	var entries []LyricEntry
 	lines := strings.Split(content, "\n")
 
-	// Skip WEBVTT header
 	start := 0
 	for i, line := range lines {
-		if strings.HasPrefix(line, "WEBVTT") {
+		if strings.HasPrefix(strings.TrimSpace(line), "WEBVTT") {
 			start = i + 1
 			break
 		}
 	}
 
-	vttRegex := regexp.MustCompile(`(\d{2}):(\d{2})\.(\d{3})\s*-->\s*\d{2}:\d{2}\.\d{3}`)
+	// Capture groups: 1=h? (optional), 2=mm, 3=ss, 4=mmm. End side ignored.
+	// Per the WebVTT spec, minutes and seconds are exactly 2 digits and
+	// milliseconds are exactly 3 digits; hours (when present) may be any
+	// length.
+	vttRegex := regexp.MustCompile(`(?:(\d+):)?(\d{2}):(\d{2})\.(\d{3})\s*-->\s*(?:\d+:)?\d{2}:\d{2}\.\d{3}`)
 
 	for i := start; i < len(lines); i++ {
 		line := strings.TrimSpace(lines[i])
 		matches := vttRegex.FindStringSubmatch(line)
-		if len(matches) == 4 {
-			minutes, _ := strconv.Atoi(matches[1])
-			seconds, _ := strconv.Atoi(matches[2])
-			milliseconds, _ := strconv.Atoi(matches[3])
-
-			// Get text from next non-empty line
-			text := ""
-			for j := i + 1; j < len(lines); j++ {
-				nextLine := strings.TrimSpace(lines[j])
-				if nextLine == "" {
-					break
-				}
-				if text != "" {
-					text += " "
-				}
-				text += nextLine
-			}
-
-			if text == "" {
-				continue
-			}
-
-			totalMs := uint32((minutes*60+seconds)*1000 + milliseconds)
-			entries = append(entries, LyricEntry{Text: text, Ms: totalMs})
+		if len(matches) != 5 {
+			continue
 		}
+
+		hours := 0
+		if matches[1] != "" {
+			hours, _ = strconv.Atoi(matches[1])
+		}
+		minutes, _ := strconv.Atoi(matches[2])
+		seconds, _ := strconv.Atoi(matches[3])
+		milliseconds, _ := strconv.Atoi(matches[4])
+
+		text := ""
+		for j := i + 1; j < len(lines); j++ {
+			nextLine := strings.TrimSpace(lines[j])
+			if nextLine == "" {
+				break
+			}
+			if text != "" {
+				text += " "
+			}
+			text += nextLine
+		}
+
+		if text == "" {
+			continue
+		}
+
+		totalMs := uint32((hours*3600+minutes*60+seconds)*1000 + milliseconds)
+		entries = append(entries, LyricEntry{Text: text, Ms: totalMs})
 	}
 
 	if len(entries) == 0 {

--- a/sylt_test.go
+++ b/sylt_test.go
@@ -265,6 +265,18 @@ Line one`,
 			},
 			wantErr: false,
 		},
+		{
+			name: "VTT body containing timestamp-like text is not re-parsed",
+			content: `WEBVTT
+
+00:01.000 --> 00:02.000
+00:99.999 --> 00:50.000
+followup line`,
+			want: []LyricEntry{
+				{Text: "00:99.999 --> 00:50.000 followup line", Ms: 1000},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/sylt_test.go
+++ b/sylt_test.go
@@ -86,6 +86,36 @@ func TestParseLRC(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name:    "multiple timestamps on one line",
+			content: `[00:10.00][00:20.00]Chorus line`,
+			want: []LyricEntry{
+				{Text: "Chorus line", Ms: 10000},
+				{Text: "Chorus line", Ms: 20000},
+			},
+			wantErr: false,
+		},
+		{
+			name: "mixed single and multi-timestamp lines",
+			content: `[00:05.00]Intro
+[00:10.00][00:20.00][00:30.00]Repeated`,
+			want: []LyricEntry{
+				{Text: "Intro", Ms: 5000},
+				{Text: "Repeated", Ms: 10000},
+				{Text: "Repeated", Ms: 20000},
+				{Text: "Repeated", Ms: 30000},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "multiple timestamps with 3-digit fractions",
+			content: `[00:01.500][00:02.500]X`,
+			want: []LyricEntry{
+				{Text: "X", Ms: 1500},
+				{Text: "X", Ms: 2500},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/sylt_test.go
+++ b/sylt_test.go
@@ -215,6 +215,56 @@ Line two`,
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "VTT with hours",
+			content: `WEBVTT
+
+01:00:12.340 --> 01:00:15.000
+Line one
+
+01:00:25.670 --> 01:00:28.000
+Line two`,
+			want: []LyricEntry{
+				{Text: "Line one", Ms: 3612340},
+				{Text: "Line two", Ms: 3625670},
+			},
+			wantErr: false,
+		},
+		{
+			name: "VTT mixed hours and no-hours",
+			content: `WEBVTT
+
+00:12.340 --> 00:15.000
+Line one
+
+01:00:25.670 --> 01:00:28.000
+Line two`,
+			want: []LyricEntry{
+				{Text: "Line one", Ms: 12340},
+				{Text: "Line two", Ms: 3625670},
+			},
+			wantErr: false,
+		},
+		{
+			name: "VTT with extra whitespace around arrow",
+			content: `WEBVTT
+
+00:12.340  -->  00:15.000
+Line one`,
+			want: []LyricEntry{
+				{Text: "Line one", Ms: 12340},
+			},
+			wantErr: false,
+		},
+		{
+			name: "VTT without WEBVTT header",
+			content: `00:12.340 --> 00:15.000
+Line one`,
+			want: []LyricEntry{
+				{Text: "Line one", Ms: 12340},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `parseLRC` now supports lines with multiple leading timestamps (e.g. `[00:10.00][00:20.00]Chorus`), producing one entry per timestamp. Single-timestamp behavior is unchanged.
- `parseVTT` now accepts optional hours (`hh:mm:ss.mmm`), flexible whitespace around `-->`, and content without a `WEBVTT` header line.

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] New table cases cover multi-timestamp LRC, hours-bearing VTT, mixed forms, extra whitespace, and missing header.

Closes #9
Closes #10