### PR TITLE
Code quality: constants, language normalization, encoding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Features
 
 - Supported input formats: LRC, SRT, and VTT
-- Configurable language codes (ISO 639-2 format)
+- Configurable language codes (case-insensitive 3-letter ISO 639-2/B codes, e.g. `eng`, `zho`, `und`)
 - Read and display existing SYLT lyrics from MP3 files
 - Creates output files with " - sylt" suffix to preserve originals
 
@@ -52,6 +52,21 @@ go-sylt [--lang <code>] <mp3_file> [lyrics_file]
 # Read existing SYLT lyrics from MP3 file and display
 ./go-sylt song.mp3
 ```
+
+### Language codes
+
+`--lang` accepts any 3-letter ISO 639-2 code and is case-insensitive (`ENG`, `Eng`, and `eng` are all accepted and stored as `eng`). Common values:
+
+- `eng` — English
+- `zho` — Chinese
+- `jpn` — Japanese
+- `kor` — Korean
+- `spa` — Spanish
+- `fra` — French
+- `deu` — German
+- `und` — undetermined (default)
+
+For the full list, see the [ISO 639-2 language code list](https://www.loc.gov/standards/iso639-2/php/code_list.php).
 
 ## Output
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ The tool creates a new MP3 file with the same name as the input file but with " 
 
 - Input: `song.mp3` → Output: `song - sylt.mp3`
 
+## Encoding
+
+When writing SYLT frames, `go-sylt` always uses:
+
+- **Text encoding:** UTF-8 (ID3v2 encoding byte `0x03`)
+- **Timestamp format:** absolute milliseconds (`0x02`)
+- **Content type:** lyrics (`0x01`)
+
+This matches the format used by most modern players and avoids surrogate-pair pitfalls that affect UTF-16 handling. When reading SYLT frames, all four ID3v2 text encodings are supported (ISO-8859-1, UTF-16 with BOM, UTF-16 big-endian, UTF-8) so files written by other tools are readable.
+
+If you need to write a non-UTF-8 SYLT frame, please open an issue describing your use case.
+
 ## Credits
 
 - [github.com/bogem/id3v2/v2](https://github.com/bogem/id3v2) - ID3v2 tag manipulation

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Features
 
 - Supported input formats: LRC, SRT, and VTT
-- Configurable language codes (case-insensitive 3-letter ISO 639-2/B codes, e.g. `eng`, `zho`, `und`)
+- Configurable language codes (case-insensitive 3-letter ISO 639-2 codes, e.g. `eng`, `zho`, `und`)
 - Read and display existing SYLT lyrics from MP3 files
 - Creates output files with " - sylt" suffix to preserve originals
 

--- a/main.go
+++ b/main.go
@@ -45,12 +45,13 @@ func main() {
 		mp3File := args[0]
 		lyricsFile := args[1]
 
-		if err := validateLanguageCode(lang); err != nil {
+		normLang, err := normalizeLanguageCode(lang)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
-		if err := processFiles(mp3File, lyricsFile, lang); err != nil {
+		if err := processFiles(mp3File, lyricsFile, normLang); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}

--- a/sylt.go
+++ b/sylt.go
@@ -209,7 +209,14 @@ func parseVTT(content string) ([]LyricEntry, error) {
 	return entries, nil
 }
 
-// buildSYLT creates SYLT frame payload
+// buildSYLT creates a SYLT frame payload per the ID3v2.4 spec.
+//
+// The payload always uses UTF-8 text encoding (encodingUTF8), milliseconds
+// timestamp format (timestampFormatMilliseconds), and the lyrics content
+// type (contentTypeLyrics). Other ID3v2 encodings (Latin-1, UTF-16 with
+// BOM, UTF-16BE) and content types are handled on read in parseSYLTFrame
+// but are not currently produced on write — see README "Encoding" for the
+// rationale and parseSYLTFrame for the read-side support.
 func buildSYLT(entries []LyricEntry, lang string) []byte {
 	buf := make([]byte, 0, 128)
 	buf = append(buf, encodingUTF8)                // text encoding UTF-8

--- a/sylt.go
+++ b/sylt.go
@@ -45,6 +45,16 @@ func validateLanguageCode(lang string) error {
 	return nil
 }
 
+// normalizeLanguageCode lowercases the input and validates it as a 3-letter
+// ISO 639-2 code. Returns the normalized code on success.
+func normalizeLanguageCode(lang string) (string, error) {
+	lower := strings.ToLower(lang)
+	if err := validateLanguageCode(lower); err != nil {
+		return "", err
+	}
+	return lower, nil
+}
+
 // parseLyrics detects format and parses lyrics file
 func parseLyrics(content string, filename string) ([]LyricEntry, error) {
 	ext := strings.ToLower(filepath.Ext(filename))

--- a/sylt.go
+++ b/sylt.go
@@ -12,6 +12,20 @@ import (
 	id3v2 "github.com/bogem/id3v2/v2"
 )
 
+// SYLT frame byte constants per the ID3v2.4 SYLT spec.
+const (
+	encodingISO88591 byte = 0x00 // ISO-8859-1 (Latin-1)
+	encodingUTF16BOM byte = 0x01 // UTF-16 with BOM
+	encodingUTF16BE  byte = 0x02 // UTF-16 big-endian, no BOM
+	encodingUTF8     byte = 0x03 // UTF-8
+
+	timestampFormatMilliseconds byte = 0x02 // absolute milliseconds
+
+	contentTypeLyrics byte = 0x01
+
+	nullByte byte = 0x00
+)
+
 type LyricEntry struct {
 	Text string
 	Ms   uint32
@@ -188,15 +202,15 @@ func parseVTT(content string) ([]LyricEntry, error) {
 // buildSYLT creates SYLT frame payload
 func buildSYLT(entries []LyricEntry, lang string) []byte {
 	buf := make([]byte, 0, 128)
-	buf = append(buf, 0x03)            // text encoding UTF-8
-	buf = append(buf, []byte(lang)...) // language (3 bytes)
-	buf = append(buf, 0x02)            // timestamp format: milliseconds
-	buf = append(buf, 0x01)            // content type: lyrics
-	buf = append(buf, 0x00)            // empty content descriptor (UTF-8 NUL)
+	buf = append(buf, encodingUTF8)                // text encoding UTF-8
+	buf = append(buf, []byte(lang)...)             // language (3 bytes)
+	buf = append(buf, timestampFormatMilliseconds) // timestamp format
+	buf = append(buf, contentTypeLyrics)           // content type
+	buf = append(buf, nullByte)                    // empty content descriptor terminator
 
 	for _, entry := range entries {
 		buf = append(buf, []byte(entry.Text)...)
-		buf = append(buf, 0x00) // UTF-8 terminator
+		buf = append(buf, nullByte) // text terminator
 		ts := make([]byte, 4)
 		binary.BigEndian.PutUint32(ts, entry.Ms)
 		buf = append(buf, ts...)
@@ -295,12 +309,12 @@ func parseSYLTFrame(frameData []byte) ([]LyricEntry, string, error) {
 	encoding := frameData[0]
 	lang := string(frameData[1:4])
 	timestampFormat := frameData[4]
-	if timestampFormat != 0x02 {
+	if timestampFormat != timestampFormatMilliseconds {
 		return nil, "", fmt.Errorf("unsupported timestamp format: 0x%02x", timestampFormat)
 	}
 
 	contentType := frameData[5]
-	if contentType != 0x01 {
+	if contentType != contentTypeLyrics {
 		return nil, "", fmt.Errorf("unsupported content type: 0x%02x", contentType)
 	}
 
@@ -340,16 +354,16 @@ func parseSYLTFrame(frameData []byte) ([]LyricEntry, string, error) {
 // getTextTerminator returns the terminator bytes for the given encoding
 func getTextTerminator(encoding byte) []byte {
 	switch encoding {
-	case 0x00: // ISO-8859-1 (Latin1)
-		return []byte{0x00}
-	case 0x01: // UTF-16 with BOM
-		return []byte{0x00, 0x00}
-	case 0x02: // UTF-16BE without BOM
-		return []byte{0x00, 0x00}
-	case 0x03: // UTF-8
-		return []byte{0x00}
+	case encodingISO88591:
+		return []byte{nullByte}
+	case encodingUTF16BOM:
+		return []byte{nullByte, nullByte}
+	case encodingUTF16BE:
+		return []byte{nullByte, nullByte}
+	case encodingUTF8:
+		return []byte{nullByte}
 	default:
-		return []byte{0x00} // fallback to single byte
+		return []byte{nullByte} // fallback to single byte
 	}
 }
 
@@ -382,7 +396,7 @@ func readEncodedText(data []byte, pos int, encoding byte) (string, int, error) {
 
 	// For UTF-16, we need to advance by 2 bytes at a time to maintain alignment
 	step := 1
-	if encoding == 0x01 || encoding == 0x02 {
+	if encoding == encodingUTF16BOM || encoding == encodingUTF16BE {
 		step = 2
 	}
 
@@ -424,14 +438,14 @@ func readEncodedText(data []byte, pos int, encoding byte) (string, int, error) {
 // decodeText decodes text bytes according to the specified encoding
 func decodeText(data []byte, encoding byte) (string, error) {
 	switch encoding {
-	case 0x00: // ISO-8859-1 (Latin1)
+	case encodingISO88591: // ISO-8859-1 (Latin1)
 		// Convert Latin1 to UTF-8
 		runes := make([]rune, len(data))
 		for i, b := range data {
 			runes[i] = rune(b)
 		}
 		return string(runes), nil
-	case 0x01: // UTF-16 with BOM
+	case encodingUTF16BOM: // UTF-16 with BOM
 		if len(data) == 0 {
 			return "", nil
 		}
@@ -449,9 +463,9 @@ func decodeText(data []byte, encoding byte) (string, error) {
 			// No BOM, assume little endian (common default)
 			return decodeUTF16LE(data)
 		}
-	case 0x02: // UTF-16BE without BOM
+	case encodingUTF16BE: // UTF-16BE without BOM
 		return decodeUTF16BE(data)
-	case 0x03: // UTF-8
+	case encodingUTF8: // UTF-8
 		return string(data), nil
 	default:
 		return "", fmt.Errorf("unsupported encoding: 0x%02x", encoding)

--- a/sylt_test.go
+++ b/sylt_test.go
@@ -622,3 +622,35 @@ func TestReadEncodedText(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeLanguageCode(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"eng", "eng", false},
+		{"ENG", "eng", false},
+		{"Eng", "eng", false},
+		{"zho", "zho", false},
+		{"ZHO", "zho", false},
+		{"und", "und", false},
+		{"en", "", true},   // too short
+		{"engl", "", true}, // too long
+		{"e1g", "", true},  // contains digit
+		{"e-g", "", true},  // contains hyphen
+		{"", "", true},     // empty
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := normalizeLanguageCode(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("normalizeLanguageCode(%q) err = %v, wantErr %v", tt.in, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("normalizeLanguageCode(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Introduces a named-constants block for SYLT encoding values, timestamp formats, content types, and the null terminator; replaces magic bytes throughout `sylt.go`.
- Adds `normalizeLanguageCode` so `--lang ENG` / `--lang Eng` work and are stored as `eng`. `validateLanguageCode` keeps its strict-lowercase contract for the existing private test.
- Documents accepted ISO 639-2 codes and the SYLT encoding asymmetry (UTF-8/ms/lyrics on write, all four encodings on read) in README and on `buildSYLT`.

## Test plan
- [x] `go test ./...` passes (existing tests still pass, new `TestNormalizeLanguageCode` added).
- [x] `go vet ./...` clean.
- [ ] Manual: `./go-sylt --lang ENG song.mp3 lyrics.lrc` succeeds and writes a `eng` SYLT frame.

Closes #11
Closes #12
Closes #14